### PR TITLE
Add Sagas realm for reading journal

### DIFF
--- a/src/app/[realm]/[id]/CardDetail.tsx
+++ b/src/app/[realm]/[id]/CardDetail.tsx
@@ -69,23 +69,21 @@ export function CardDetail({ card, realmInfo }: CardDetailProps) {
               {card.title}
             </p>
 
-            {/* Secondary info */}
-            <div className="mt-2 flex flex-wrap items-center gap-4 text-ink-600 dark:text-parchment-400">
-              {card.phonetic ? (
-                <span className="font-mono">
-                  Phonetic: /{card.phonetic}/
-                </span>
-              ) : (
-                <span className="font-mono italic text-ink-400 dark:text-parchment-500">
-                  Numeral only — no phonetic value
-                </span>
-              )}
-              {card.numericValue && (
-                <span className="font-mono">
-                  Numeric: {card.numericValue}
-                </span>
-              )}
-            </div>
+            {/* Secondary info - only show for runes/letters with phonetic or numeric values */}
+            {(card.phonetic || card.numericValue) && (
+              <div className="mt-2 flex flex-wrap items-center gap-4 text-ink-600 dark:text-parchment-400">
+                {card.phonetic && (
+                  <span className="font-mono">
+                    Phonetic: /{card.phonetic}/
+                  </span>
+                )}
+                {card.numericValue && (
+                  <span className="font-mono">
+                    Numeric: {card.numericValue}
+                  </span>
+                )}
+              </div>
+            )}
           </div>
         </div>
 
@@ -94,6 +92,18 @@ export function CardDetail({ card, realmInfo }: CardDetailProps) {
           <p className="mt-4 text-ink-600 dark:text-parchment-400 border-t border-gothic-200 dark:border-ink-700 pt-4">
             {card.secondaryText}
           </p>
+        )}
+
+        {/* Sources for saga entries */}
+        {card.sources && card.sources.length > 0 && (
+          <div className="mt-4 border-t border-gothic-200 pt-4">
+            <span className="text-sm font-medium text-ink-500 dark:text-ink-400">
+              {card.sources.length === 1 ? 'Source: ' : 'Sources: '}
+            </span>
+            <span className="text-ink-700 dark:text-ink-300 italic">
+              {card.sources.join(' · ')}
+            </span>
+          </div>
         )}
       </motion.div>
 

--- a/src/components/CardPreview.tsx
+++ b/src/components/CardPreview.tsx
@@ -98,6 +98,13 @@ export function CardPreview({ card }: CardPreviewProps) {
                   )}
                 </div>
               )}
+
+              {/* Sources for saga entries */}
+              {card.sources && card.sources.length > 0 && (
+                <p className="mt-3 text-xs text-ink-400 dark:text-ink-500 italic line-clamp-1">
+                  {card.sources.join(' · ')}
+                </p>
+              )}
             </div>
           </article>
         </Link>

--- a/src/content/sagas/001-example-reading.mdx
+++ b/src/content/sagas/001-example-reading.mdx
@@ -1,0 +1,33 @@
+---
+id: yngvi-first-king
+realm: sagas
+title: "Yngvi: Progenitor of the Ynglings"
+subtitle: "Ynglinga saga, Chapter 10"
+primaryText: "Njörðr átti þá konu, er Skaði hét. Skaði vildi eigi samfarar við hann."
+secondaryText: "Njörðr then had a wife called Skaði. Skaði did not want to live with him."
+tags: [ynglinga, sweden, gods, njordr, skadi]
+shareCopy: "From the Ynglinga saga: The marriage of Njörðr and Skaði, and the line of Swedish kings."
+order: 1
+sources:
+  - Heimskringla
+  - Ynglinga saga
+---
+
+## Context
+
+This passage comes from Chapter 10 of Ynglinga saga, where Snorri describes the ill-fated marriage between the Vanir god Njörðr and the giantess Skaði. Their incompatibility—she loved the mountains, he the sea—became legendary.
+
+## Vocabulary
+
+- **átti** (v.) — owned, had, possessed (past tense of *eiga*)
+- **konu** (f. acc.) — wife, woman
+- **hét** (v.) — was called, was named
+- **vildi** (v.) — wanted, wished (past tense of *vilja*)
+- **samfarar** (f. pl. acc.) — living together, cohabitation
+- **við** (prep.) — with
+
+## Commentary
+
+The Ynglinga saga traces the legendary origins of the Swedish royal dynasty (the Ynglings) back to the gods themselves. Snorri euhemerizes the Norse gods as ancient kings who came from Asia (hence "Æsir"), presenting mythology as distorted history.
+
+Yngvi-Freyr, son of Njörðr, would become the divine ancestor of the Swedish kings, giving the dynasty its name.

--- a/src/content/sagas/_TEMPLATE.mdx
+++ b/src/content/sagas/_TEMPLATE.mdx
@@ -1,0 +1,26 @@
+---
+id: your-reading-id
+realm: sagas
+title: "Title of the Passage"
+subtitle: "Brief context"
+primaryText: "Old Norse text here."
+secondaryText: "Your English translation."
+tags: [saga-name, theme, topic]
+shareCopy: "Share text for social media."
+order: 999
+sources:
+  - Source Saga Name
+  - Optional Parent Work
+---
+
+## Notes
+
+Your reading notes here.
+
+## Vocabulary
+
+- **word** (gender) - meaning
+
+## Commentary
+
+Your analysis and reflections.

--- a/src/lib/cards.ts
+++ b/src/lib/cards.ts
@@ -15,7 +15,7 @@ export async function getCardsByRealm(realm: Realm): Promise<Card[]> {
     return []
   }
 
-  const files = fs.readdirSync(realmDir).filter(f => f.endsWith('.mdx'))
+  const files = fs.readdirSync(realmDir).filter(f => f.endsWith('.mdx') && !f.startsWith('_'))
 
   const cards = files.map(filename => {
     const filePath = path.join(realmDir, filename)
@@ -32,7 +32,7 @@ export async function getCardsByRealm(realm: Realm): Promise<Card[]> {
  * Get all cards across all realms
  */
 export async function getAllCards(): Promise<Card[]> {
-  const realms: Realm[] = ['gothic', 'voluspa', 'havamal', 'younger-futhark', 'elder-futhark']
+  const realms: Realm[] = ['gothic', 'voluspa', 'havamal', 'younger-futhark', 'elder-futhark', 'sagas']
 
   const allCards = await Promise.all(
     realms.map(realm => getCardsByRealm(realm))
@@ -46,7 +46,7 @@ export async function getAllCards(): Promise<Card[]> {
  */
 export async function getCard(realm: Realm, id: string): Promise<CardWithContent | null> {
   const realmDir = path.join(contentDirectory, realm)
-  const files = fs.readdirSync(realmDir).filter(f => f.endsWith('.mdx'))
+  const files = fs.readdirSync(realmDir).filter(f => f.endsWith('.mdx') && !f.startsWith('_'))
 
   for (const filename of files) {
     const filePath = path.join(realmDir, filename)

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -9,6 +9,7 @@ export type Realm =
   | 'elder-futhark'
   | 'bind-runes'
   | 'galdrastafir'
+  | 'sagas'
 
 /**
  * Core Card schema - the atomic unit of content
@@ -70,6 +71,12 @@ export interface Card {
 
   /** Order within the realm (for alphabets, verse numbers) */
   order: number
+
+  /**
+   * Source texts for saga entries
+   * e.g., ['Heimskringla', 'Ynglinga saga']
+   */
+  sources?: string[]
 }
 
 /**
@@ -90,6 +97,7 @@ export interface CardFrontmatter {
   publishDate?: string
   published?: boolean
   order: number
+  sources?: string[]
 }
 
 /**
@@ -153,5 +161,11 @@ export const REALM_INFO: Record<Realm, Omit<RealmInfo, 'cardCount'>> = {
     name: 'Galdrastafir',
     description: 'Icelandic magical staves',
     color: 'ink',
+  },
+  sagas: {
+    id: 'sagas',
+    name: 'Sagas',
+    description: 'Readings from the Icelandic sagas',
+    color: 'parchment',
   },
 }


### PR DESCRIPTION
## Summary

- Add `sagas` realm for tracking readings from Viking Language 2 and other saga sources
- Add `sources` field to Card interface (array, supports multiple sources like "Heimskringla", "Ynglinga saga")
- Display sources in both CardDetail page and CardPreview grid cards
- Include example entry and `_TEMPLATE.mdx` for easy new entry creation

## Usage

Create new entries in `src/content/sagas/` using the template:

```yaml
sources:
  - Heimskringla
  - Ynglinga saga
```

## Test plan

- [ ] Verify sagas realm appears in realm selector
- [ ] Verify example entry renders with sources displayed
- [ ] Verify sources show in both card preview and detail views
- [ ] Verify dark mode styling for sources

🤖 Generated with [Claude Code](https://claude.com/claude-code)